### PR TITLE
Bump default OS image to Ubuntu 22.04 and droplet size to current slugs

### DIFF
--- a/.templates/server.yml
+++ b/.templates/server.yml
@@ -1,9 +1,9 @@
 ---
 server:
   ssh_key_name: "Ansible / Minecraft"
-  image: ubuntu-16-04-x64
+  image: ubuntu-22-04-x64
   region: sfo2
-  size: 2gb
+  size: s-2vcpu-2gb
   name: minecraft
 volume:
   block_size: 10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Stops the `minecraft` service, unmounts the volume, destroys the droplet (`deleg
 
 ## Gotchas
 
-- The playbooks target Ubuntu 16.04 (`image: ubuntu-16-04-x64` in `.templates/server.yml`). DigitalOcean has since deprecated that image slug; if provisioning fails with an image-not-found error, update `vars/server.yml` to a supported slug rather than patching the playbook.
+- The default template targets Ubuntu 22.04 LTS (`image: ubuntu-22-04-x64`). 24.04 also works; bump when 22.04 nears its April 2027 standard-support end. DO periodically deprecates old slugs — see https://slugs.do-api.dev/ for current options.
 - The `community.digitalocean` collection is marked deprecated upstream and will be removed from Ansible 13. No drop-in replacement yet — keep an eye on `digitalocean.cloud` (official vendor collection) as a future migration path.
-- `make setup` runs `pip install -U -r requirements.txt` against the ambient Python, which installs `pipenv==10.1.2` globally. If a newer pipenv is already installed system-wide, this can downgrade it.
+- `make setup` runs `pip install -U -r requirements.txt` against the ambient Python, which installs/upgrades `pipenv` (pinned to `>=2024.0`) globally. Downgrade risk of the previous `==10.1.2` pin is gone; the remaining rough edge is that it's a global install rather than an isolated tool install via pipx. #14 tracks moving off pipenv entirely.
 - Relative paths in playbooks (`../vars/...`, `../keys/...`, `../templates/...`, `../inventory`) assume playbooks are run from the repo root, which is what `make` does. Running `ansible-playbook` from inside `playbooks/` will not work.

--- a/README.md
+++ b/README.md
@@ -71,11 +71,13 @@ Sensible defaults have been chosen for the server creation options, but you can 
 # vars/server.yml
 server:
   ssh_key_name: "Ansible / Minecraft"
-  image_id: ubuntu-16-04-x64
-  region_id: nyc3
-  size_id: 4gb
+  image: ubuntu-22-04-x64
+  region: nyc3
+  size: s-2vcpu-2gb
   name: minecraft
 ```
+
+See the [DigitalOcean size slugs reference](https://slugs.do-api.dev/) for other options. Legacy slugs like `2gb`, `4gb` were retired — use `s-<vcpu>-<ram>` (basic), `g-<vcpu>-<ram>` (general purpose), or other current formats.
 
 ### Minecraft Server Configuration
 


### PR DESCRIPTION
## Summary

Config-only update to the `.templates/server.yml` defaults and the matching docs:

- `image: ubuntu-16-04-x64` → `ubuntu-22-04-x64`. The 16.04 slug is deprecated by DigitalOcean and creates fail with image-not-found; 22.04 LTS has standard support through April 2027 (24.04 also works but 22.04 is what the PR #15 live test used).
- `size: 2gb` → `s-2vcpu-2gb`. Legacy memory-only size slugs (`2gb`, `4gb`, etc.) were retired in favor of the `<class>-<vcpu>-<ram>` format. `s-2vcpu-2gb` is a mild bump over the strict `s-1vcpu-2gb` equivalent; the second vCPU helps Minecraft chunk generation and mob AI without adding much cost.
- README.md: updated the Server Creation example and added a pointer to https://slugs.do-api.dev/ for other size options.
- CLAUDE.md: updated the image-slug gotcha (no longer flagging 16.04 as the default) and the pipenv gotcha (downgrade risk from the old `10.1.2` pin no longer applies).

## Test plan

- [ ] `make provision` against a throwaway droplet — already validated during PR #15's live test with `ubuntu-22-04-x64` + `s-2vcpu-2gb` + `nyc3`. No need to rerun unless you want belt-and-suspenders.
- [ ] `make destroy` — ditto.

Closes #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)