### PR TITLE
Add on-demand provision/destroy GitHub Actions

### DIFF
--- a/.github/workflows/auto-destroy.yml
+++ b/.github/workflows/auto-destroy.yml
@@ -1,0 +1,131 @@
+name: Auto-destroy expired Minecraft server
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: minecraft-server
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-expiry:
+    runs-on: ubuntu-latest
+    outputs:
+      expired: ${{ steps.check.outputs.expired }}
+      ip: ${{ steps.check.outputs.ip }}
+    steps:
+      - name: Look up droplet and parse expiry tag
+        id: check
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+        run: |
+          DROPLET=$(curl -fsS -H "Authorization: Bearer ${DO_API_KEY}" \
+            'https://api.digitalocean.com/v2/droplets?tag_name=ansible-on-demand' \
+            | jq '.droplets[] | select(.name == "minecraft")' | jq -s '.[0]')
+          if [ "$DROPLET" = "null" ] || [ -z "$DROPLET" ]; then
+            echo "No droplet tagged ansible-on-demand."
+            echo "expired=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          EXPIRES_AT=$(echo "$DROPLET" | jq -r '.tags[] | select(startswith("expires-"))' | sed 's/^expires-//' | head -1)
+          IP=$(echo "$DROPLET" | jq -r '.networks.v4[] | select(.type=="public") | .ip_address')
+          NOW=$(date -u +%s)
+          if [ -z "$EXPIRES_AT" ]; then
+            echo "Droplet has no expires-<unix> tag — leaving alone."
+            echo "expired=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Now: ${NOW}, expires: ${EXPIRES_AT}"
+          if [ "$NOW" -ge "$EXPIRES_AT" ]; then
+            echo "expired=true" >> "$GITHUB_OUTPUT"
+            echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+          else
+            echo "expired=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  destroy:
+    needs: check-expiry
+    if: needs.check-expiry.outputs.expired == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pipenv and Ansible deps
+        run: |
+          pip install -U -r requirements.txt
+          pipenv install
+          pipenv run ansible-galaxy install -r requirements.yml
+
+      - name: Write SSH keypair
+        env:
+          ANSIBLE_SSH_PRIVATE_KEY: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+          ANSIBLE_SSH_PUBLIC_KEY: ${{ secrets.ANSIBLE_SSH_PUBLIC_KEY }}
+        run: |
+          mkdir -p keys
+          printf '%s\n' "$ANSIBLE_SSH_PRIVATE_KEY" > keys/ansible
+          printf '%s\n' "$ANSIBLE_SSH_PUBLIC_KEY" > keys/ansible.pub
+          chmod 600 keys/ansible
+          chmod 644 keys/ansible.pub
+
+      - name: Generate vars/credentials.yml
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+          DNSIMPLE_ACCOUNT_EMAIL: ${{ secrets.DNSIMPLE_ACCOUNT_EMAIL }}
+          DNSIMPLE_ACCOUNT_API_TOKEN: ${{ secrets.DNSIMPLE_ACCOUNT_API_TOKEN }}
+        run: |
+          mkdir -p vars
+          cat > vars/credentials.yml <<EOF
+          ---
+          credentials:
+            digital_ocean:
+              api_key: "${DO_API_KEY}"
+            dnsimple:
+              account_email: "${DNSIMPLE_ACCOUNT_EMAIL}"
+              account_api_token: "${DNSIMPLE_ACCOUNT_API_TOKEN}"
+          EOF
+          chmod 600 vars/credentials.yml
+
+      - name: Generate vars/server.yml
+        env:
+          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+        run: |
+          cat > vars/server.yml <<EOF
+          ---
+          server:
+            ssh_key_name: "Minecraft CI"
+            name: minecraft
+          volume:
+            name: minecraft-data
+          dns:
+            domain: "${DNSIMPLE_DOMAIN}"
+            hostname: minecraft
+            ttl: 300
+          minecraft_home: /srv/minecraft
+          EOF
+
+      - name: Build inventory
+        run: echo "minecraft ansible_ssh_host=${{ needs.check-expiry.outputs.ip }} ansible_ssh_user=root" > inventory
+
+      - name: Destroy droplet
+        run: pipenv run ansible-playbook playbooks/destroy.yml
+
+      - name: Write summary
+        run: |
+          {
+            echo "## Auto-destroyed expired Minecraft droplet"
+            echo
+            echo "- IP: \`${{ needs.check-expiry.outputs.ip }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -1,0 +1,100 @@
+name: Destroy Minecraft server
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: minecraft-server
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    environment: minecraft-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pipenv and Ansible deps
+        run: |
+          pip install -U -r requirements.txt
+          pipenv install
+          pipenv run ansible-galaxy install -r requirements.yml
+
+      - name: Write SSH keypair
+        env:
+          ANSIBLE_SSH_PRIVATE_KEY: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+          ANSIBLE_SSH_PUBLIC_KEY: ${{ secrets.ANSIBLE_SSH_PUBLIC_KEY }}
+        run: |
+          mkdir -p keys
+          printf '%s\n' "$ANSIBLE_SSH_PRIVATE_KEY" > keys/ansible
+          printf '%s\n' "$ANSIBLE_SSH_PUBLIC_KEY" > keys/ansible.pub
+          chmod 600 keys/ansible
+          chmod 644 keys/ansible.pub
+
+      - name: Generate vars/credentials.yml
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+          DNSIMPLE_ACCOUNT_EMAIL: ${{ secrets.DNSIMPLE_ACCOUNT_EMAIL }}
+          DNSIMPLE_ACCOUNT_API_TOKEN: ${{ secrets.DNSIMPLE_ACCOUNT_API_TOKEN }}
+        run: |
+          mkdir -p vars
+          cat > vars/credentials.yml <<EOF
+          ---
+          credentials:
+            digital_ocean:
+              api_key: "${DO_API_KEY}"
+            dnsimple:
+              account_email: "${DNSIMPLE_ACCOUNT_EMAIL}"
+              account_api_token: "${DNSIMPLE_ACCOUNT_API_TOKEN}"
+          EOF
+          chmod 600 vars/credentials.yml
+
+      - name: Generate vars/server.yml
+        env:
+          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+        run: |
+          cat > vars/server.yml <<EOF
+          ---
+          server:
+            ssh_key_name: "Minecraft CI"
+            name: minecraft
+          volume:
+            name: minecraft-data
+          dns:
+            domain: "${DNSIMPLE_DOMAIN}"
+            hostname: minecraft
+            ttl: 300
+          minecraft_home: /srv/minecraft
+          EOF
+
+      - name: Reconstruct inventory from DO API
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+        run: |
+          IP=$(curl -fsS -H "Authorization: Bearer ${DO_API_KEY}" \
+            'https://api.digitalocean.com/v2/droplets?name=minecraft' \
+            | jq -r '.droplets[0].networks.v4[] | select(.type=="public") | .ip_address')
+          if [ -z "$IP" ] || [ "$IP" = "null" ]; then
+            echo "No live droplet named 'minecraft' — nothing to destroy."
+            exit 0
+          fi
+          echo "minecraft ansible_ssh_host=${IP} ansible_ssh_user=root" > inventory
+
+      - name: Destroy droplet
+        run: |
+          if [ ! -f inventory ]; then
+            echo "Skipping — no inventory."
+            exit 0
+          fi
+          pipenv run ansible-playbook playbooks/destroy.yml

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -1,0 +1,160 @@
+name: Provision Minecraft server
+
+on:
+  workflow_dispatch:
+    inputs:
+      region:
+        description: DigitalOcean region
+        required: true
+        default: nyc3
+        type: choice
+        options:
+          - nyc3
+          - sfo3
+          - ams3
+          - fra1
+          - sgp1
+      size:
+        description: Droplet size
+        required: true
+        default: s-2vcpu-4gb
+        type: choice
+        options:
+          - s-2vcpu-2gb
+          - s-2vcpu-4gb
+          - s-4vcpu-8gb
+      duration_hours:
+        description: Auto-destroy after N hours
+        required: true
+        default: "4"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "4"
+          - "8"
+          - "12"
+          - "24"
+
+concurrency:
+  group: minecraft-server
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    environment: minecraft-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pipenv and Ansible deps
+        run: |
+          pip install -U -r requirements.txt
+          pipenv install
+          pipenv run ansible-galaxy install -r requirements.yml
+
+      - name: Compute expiry timestamp
+        id: expiry
+        run: |
+          DURATION=${{ inputs.duration_hours }}
+          EXPIRES_AT=$(( $(date -u +%s) + DURATION * 3600 ))
+          EXPIRES_HUMAN=$(date -u -d "@${EXPIRES_AT}" -Iseconds)
+          echo "epoch=${EXPIRES_AT}" >> "$GITHUB_OUTPUT"
+          echo "human=${EXPIRES_HUMAN}" >> "$GITHUB_OUTPUT"
+
+      - name: Write SSH keypair
+        env:
+          ANSIBLE_SSH_PRIVATE_KEY: ${{ secrets.ANSIBLE_SSH_PRIVATE_KEY }}
+          ANSIBLE_SSH_PUBLIC_KEY: ${{ secrets.ANSIBLE_SSH_PUBLIC_KEY }}
+        run: |
+          mkdir -p keys
+          printf '%s\n' "$ANSIBLE_SSH_PRIVATE_KEY" > keys/ansible
+          printf '%s\n' "$ANSIBLE_SSH_PUBLIC_KEY" > keys/ansible.pub
+          chmod 600 keys/ansible
+          chmod 644 keys/ansible.pub
+
+      - name: Generate vars/credentials.yml
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+          DNSIMPLE_ACCOUNT_EMAIL: ${{ secrets.DNSIMPLE_ACCOUNT_EMAIL }}
+          DNSIMPLE_ACCOUNT_API_TOKEN: ${{ secrets.DNSIMPLE_ACCOUNT_API_TOKEN }}
+        run: |
+          mkdir -p vars
+          cat > vars/credentials.yml <<EOF
+          ---
+          credentials:
+            digital_ocean:
+              api_key: "${DO_API_KEY}"
+            dnsimple:
+              account_email: "${DNSIMPLE_ACCOUNT_EMAIL}"
+              account_api_token: "${DNSIMPLE_ACCOUNT_API_TOKEN}"
+          EOF
+          chmod 600 vars/credentials.yml
+
+      - name: Generate vars/server.yml
+        env:
+          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          REGION: ${{ inputs.region }}
+          SIZE: ${{ inputs.size }}
+          DURATION_HOURS: ${{ inputs.duration_hours }}
+          EXPIRES_AT: ${{ steps.expiry.outputs.epoch }}
+        run: |
+          cat > vars/server.yml <<EOF
+          ---
+          server:
+            ssh_key_name: "Minecraft CI"
+            image: ubuntu-22-04-x64
+            region: "${REGION}"
+            size: "${SIZE}"
+            name: minecraft
+            tags:
+              - ansible-on-demand
+              - ttl-${DURATION_HOURS}h
+              - expires-${EXPIRES_AT}
+          volume:
+            block_size: 10
+            name: minecraft-data
+          dns:
+            domain: "${DNSIMPLE_DOMAIN}"
+            hostname: minecraft
+            ttl: 300
+          minecraft_home: /srv/minecraft
+          minecraft_version: 26.1.2
+          minecraft_java_package: openjdk-25-jre-headless
+          minecraft_accept_eula: true
+          EOF
+
+      - name: Provision droplet
+        run: pipenv run ansible-playbook playbooks/create.yml
+
+      - name: Read droplet IP from inventory
+        id: droplet
+        run: |
+          IP=$(awk '/ansible_ssh_host=/ {for(i=1;i<=NF;i++) if($i ~ /^ansible_ssh_host=/) {sub(/^ansible_ssh_host=/, "", $i); print $i}}' inventory)
+          echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+
+      - name: Write workflow summary
+        env:
+          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+        run: |
+          {
+            echo "## Minecraft server provisioned"
+            echo
+            echo "- **FQDN:** \`minecraft.${DNSIMPLE_DOMAIN}\`"
+            echo "- **IP:** \`${{ steps.droplet.outputs.ip }}\`"
+            echo "- **Region:** \`${{ inputs.region }}\`"
+            echo "- **Size:** \`${{ inputs.size }}\`"
+            echo "- **Auto-destroy after:** ${{ inputs.duration_hours }}h (\`${{ steps.expiry.outputs.human }}\`)"
+            echo "- **Connect:** \`minecraft.${DNSIMPLE_DOMAIN}:25565\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -120,3 +120,38 @@ It's important to shut down the Minecraft server process and unmount the Block S
 ```
 $ make destroy
 ```
+
+## Provisioning via GitHub Actions
+
+Three workflows under `.github/workflows/` let anyone with repo write access spin up and tear down a session server without cloning the repo locally.
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `provision.yml` | Manual (`workflow_dispatch`) | Create droplet, attach `minecraft-data` volume, install server. Inputs: region, size, `duration_hours` (used for auto-destroy). |
+| `destroy.yml` | Manual (`workflow_dispatch`) | Stop service, unmount volume, destroy droplet, remove DNS record. |
+| `auto-destroy.yml` | Cron (`*/15 * * * *`) | Inspect live droplet's `expires-<unix>` tag and run the destroy flow once the TTL has passed. |
+
+All three share concurrency group `minecraft-server` so they cannot race each other. `provision.yml` and `destroy.yml` are gated on the `minecraft-server` GitHub Environment so an explicit reviewer click is required — `auto-destroy.yml` is not gated since it runs unattended.
+
+### Required repository secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `DO_API_KEY` | DigitalOcean API token (same scopes as for local `make provision`). |
+| `DNSIMPLE_ACCOUNT_EMAIL` | DNSimple account email. |
+| `DNSIMPLE_ACCOUNT_API_TOKEN` | DNSimple API token. |
+| `DNSIMPLE_DOMAIN` | Apex domain that will host the `minecraft.<domain>` A record. |
+| `ANSIBLE_SSH_PRIVATE_KEY` | Persistent SSH private key the workflows use to manage the droplet. Generate once with `ssh-keygen -t ed25519 -N '' -f keys/ansible -C minecraft-ci` locally and copy the file contents into the secret. |
+| `ANSIBLE_SSH_PUBLIC_KEY` | Matching public key. |
+
+### One-time GitHub setup
+
+1. **Repository → Settings → Environments**: create `minecraft-server`, add yourself (and any other write-access users) under **Required reviewers**.
+2. **Repository → Settings → Secrets and variables → Actions**: add the secrets above.
+3. (Optional) Restrict `workflow_dispatch` to specific actors via branch protection / environment policies if the repo is public.
+
+### Running
+
+- **Provision**: Actions → *Provision Minecraft server* → *Run workflow* → choose region/size/duration → approve in the environment prompt → workflow summary contains the FQDN, IP, and expiry timestamp.
+- **Destroy early**: Actions → *Destroy Minecraft server* → *Run workflow* → approve.
+- **Auto-destroy**: nothing to do; cron polls every 15 min and tears down once `now >= expires-<unix>`.

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -28,6 +28,7 @@
         ssh_keys:
           - "{{ public_key_create.data.ssh_key.id }}"
         name: "{{ server.name }}"
+        tags: "{{ server.tags | default(omit) }}"
         unique_name: yes
         wait: yes
       register: server_create


### PR DESCRIPTION
## Summary
- Three workflows under `.github/workflows/` make the toolkit usable without a local checkout:
  - `provision.yml` — manual, choice inputs for region/size/`duration_hours`, env-gated
  - `destroy.yml` — manual, env-gated, rebuilds inventory from DO API lookup
  - `auto-destroy.yml` — `*/15 * * * *` cron that parses the live droplet's `expires-<unix>` tag and tears down once expired
- All three share `concurrency.group: minecraft-server` so they cannot race each other.
- `playbooks/create.yml` now forwards `server.tags` to `digital_ocean_droplet` (`| default(omit)` so local flows are unaffected).
- README adds a "Provisioning via GitHub Actions" section listing the six required secrets and the one-time environment setup.

Closes #16.

## Required setup before first run
1. Create the `minecraft-server` GitHub Environment with required reviewers (yourself + write-access users).
2. Add secrets: `DO_API_KEY`, `DNSIMPLE_ACCOUNT_EMAIL`, `DNSIMPLE_ACCOUNT_API_TOKEN`, `DNSIMPLE_DOMAIN`, `ANSIBLE_SSH_PRIVATE_KEY`, `ANSIBLE_SSH_PUBLIC_KEY`.
3. Generate a dedicated CI keypair (`ssh-keygen -t ed25519 -N '' -f keys/ansible -C minecraft-ci`) and paste both files into the secrets above.

## Test plan
- [x] YAML syntax check on all three workflows
- [x] `ansible-playbook --syntax-check playbooks/create.yml` after `tags` addition
- [x] Verified `community.digitalocean.digital_ocean_droplet` accepts `tags` (`ansible-doc`)
- [ ] After secrets + environment configured, run `provision.yml` end-to-end and confirm summary shows correct FQDN/IP/expiry
- [ ] Run `destroy.yml` — confirm droplet + DNS torn down, `minecraft-data` volume preserved
- [ ] Verify `auto-destroy.yml` no-ops when no droplet exists, and tears down once `now >= expires-<unix>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)