### PR TITLE
Per-world subdomain + level-name binding

### DIFF
--- a/.github/workflows/auto-destroy.yml
+++ b/.github/workflows/auto-destroy.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Generate vars/server.yml
         env:
-          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          DNSIMPLE_DOMAIN: ${{ vars.DNSIMPLE_DOMAIN }}
           WORLD: ${{ needs.check-expiry.outputs.world }}
         run: |
           cat > vars/server.yml <<EOF

--- a/.github/workflows/auto-destroy.yml
+++ b/.github/workflows/auto-destroy.yml
@@ -18,8 +18,9 @@ jobs:
     outputs:
       expired: ${{ steps.check.outputs.expired }}
       ip: ${{ steps.check.outputs.ip }}
+      world: ${{ steps.check.outputs.world }}
     steps:
-      - name: Look up droplet and parse expiry tag
+      - name: Look up droplet and parse tags
         id: check
         env:
           DO_API_KEY: ${{ secrets.DO_API_KEY }}
@@ -34,16 +35,18 @@ jobs:
           fi
           EXPIRES_AT=$(echo "$DROPLET" | jq -r '.tags[] | select(startswith("expires-"))' | sed 's/^expires-//' | head -1)
           IP=$(echo "$DROPLET" | jq -r '.networks.v4[] | select(.type=="public") | .ip_address')
+          WORLD=$(echo "$DROPLET" | jq -r '.tags[] | select(startswith("world-"))' | sed 's/^world-//' | head -1)
           NOW=$(date -u +%s)
           if [ -z "$EXPIRES_AT" ]; then
             echo "Droplet has no expires-<unix> tag — leaving alone."
             echo "expired=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          echo "Now: ${NOW}, expires: ${EXPIRES_AT}"
+          echo "Now: ${NOW}, expires: ${EXPIRES_AT}, world: ${WORLD}"
           if [ "$NOW" -ge "$EXPIRES_AT" ]; then
             echo "expired=true" >> "$GITHUB_OUTPUT"
             echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+            echo "world=${WORLD}" >> "$GITHUB_OUTPUT"
           else
             echo "expired=false" >> "$GITHUB_OUTPUT"
           fi
@@ -101,6 +104,7 @@ jobs:
       - name: Generate vars/server.yml
         env:
           DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          WORLD: ${{ needs.check-expiry.outputs.world }}
         run: |
           cat > vars/server.yml <<EOF
           ---
@@ -111,7 +115,7 @@ jobs:
             name: minecraft-data
           dns:
             domain: "${DNSIMPLE_DOMAIN}"
-            hostname: minecraft-server
+            hostname: "${WORLD}.minecraft"
             ttl: 300
           minecraft_home: /srv/minecraft
           EOF
@@ -127,5 +131,6 @@ jobs:
           {
             echo "## Auto-destroyed expired Minecraft droplet"
             echo
+            echo "- World: \`${{ needs.check-expiry.outputs.world }}\`"
             echo "- IP: \`${{ needs.check-expiry.outputs.ip }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -60,9 +60,34 @@ jobs:
           EOF
           chmod 600 vars/credentials.yml
 
+      - name: Look up droplet + world tag
+        id: droplet
+        env:
+          DO_API_KEY: ${{ secrets.DO_API_KEY }}
+        run: |
+          DROPLET=$(curl -fsS -H "Authorization: Bearer ${DO_API_KEY}" \
+            'https://api.digitalocean.com/v2/droplets?name=minecraft' \
+            | jq '.droplets[0]')
+          if [ "$DROPLET" = "null" ] || [ -z "$DROPLET" ]; then
+            echo "No live droplet named 'minecraft' — nothing to destroy."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          IP=$(echo "$DROPLET" | jq -r '.networks.v4[] | select(.type=="public") | .ip_address')
+          WORLD=$(echo "$DROPLET" | jq -r '.tags[] | select(startswith("world-"))' | sed 's/^world-//' | head -1)
+          if [ -z "$WORLD" ] || [ "$WORLD" = "null" ]; then
+            echo "::warning::Droplet has no world-<name> tag; DNS A record may not be cleaned up."
+            WORLD=""
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "ip=${IP}" >> "$GITHUB_OUTPUT"
+          echo "world=${WORLD}" >> "$GITHUB_OUTPUT"
+
       - name: Generate vars/server.yml
+        if: steps.droplet.outputs.found == 'true'
         env:
           DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          WORLD: ${{ steps.droplet.outputs.world }}
         run: |
           cat > vars/server.yml <<EOF
           ---
@@ -73,28 +98,15 @@ jobs:
             name: minecraft-data
           dns:
             domain: "${DNSIMPLE_DOMAIN}"
-            hostname: minecraft-server
+            hostname: "${WORLD}.minecraft"
             ttl: 300
           minecraft_home: /srv/minecraft
           EOF
 
-      - name: Reconstruct inventory from DO API
-        env:
-          DO_API_KEY: ${{ secrets.DO_API_KEY }}
-        run: |
-          IP=$(curl -fsS -H "Authorization: Bearer ${DO_API_KEY}" \
-            'https://api.digitalocean.com/v2/droplets?name=minecraft' \
-            | jq -r '.droplets[0].networks.v4[] | select(.type=="public") | .ip_address')
-          if [ -z "$IP" ] || [ "$IP" = "null" ]; then
-            echo "No live droplet named 'minecraft' — nothing to destroy."
-            exit 0
-          fi
-          echo "minecraft ansible_ssh_host=${IP} ansible_ssh_user=root" > inventory
+      - name: Build inventory
+        if: steps.droplet.outputs.found == 'true'
+        run: echo "minecraft ansible_ssh_host=${{ steps.droplet.outputs.ip }} ansible_ssh_user=root" > inventory
 
       - name: Destroy droplet
-        run: |
-          if [ ! -f inventory ]; then
-            echo "Skipping — no inventory."
-            exit 0
-          fi
-          ansible-playbook playbooks/destroy.yml
+        if: steps.droplet.outputs.found == 'true'
+        run: ansible-playbook playbooks/destroy.yml

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Generate vars/server.yml
         if: steps.droplet.outputs.found == 'true'
         env:
-          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          DNSIMPLE_DOMAIN: ${{ vars.DNSIMPLE_DOMAIN }}
           WORLD: ${{ steps.droplet.outputs.world }}
         run: |
           cat > vars/server.yml <<EOF

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -35,6 +35,11 @@ on:
           - "8"
           - "12"
           - "24"
+      world:
+        description: World name (lowercase letters, digits, hyphens; 1-30 chars)
+        required: true
+        default: world
+        type: string
 
 concurrency:
   group: minecraft-server
@@ -63,6 +68,15 @@ jobs:
           pip install -U pip
           pip install 'ansible-core~=2.18' dnsimple
           ansible-galaxy install -r requirements.yml
+
+      - name: Validate world name
+        env:
+          WORLD: ${{ inputs.world }}
+        run: |
+          if ! [[ "$WORLD" =~ ^[a-z0-9]([a-z0-9-]{0,28}[a-z0-9])?$ ]]; then
+            echo "::error::World name '${WORLD}' is invalid. Must be 1-30 chars, lowercase letters/digits/hyphens, no leading or trailing hyphen."
+            exit 1
+          fi
 
       - name: Compute expiry timestamp
         id: expiry
@@ -109,6 +123,7 @@ jobs:
           SIZE: ${{ inputs.size }}
           DURATION_HOURS: ${{ inputs.duration_hours }}
           EXPIRES_AT: ${{ steps.expiry.outputs.epoch }}
+          WORLD: ${{ inputs.world }}
         run: |
           cat > vars/server.yml <<EOF
           ---
@@ -122,17 +137,20 @@ jobs:
               - ansible-on-demand
               - ttl-${DURATION_HOURS}h
               - expires-${EXPIRES_AT}
+              - world-${WORLD}
           volume:
             block_size: 10
             name: minecraft-data
           dns:
             domain: "${DNSIMPLE_DOMAIN}"
-            hostname: minecraft-server
+            hostname: "${WORLD}.minecraft"
             ttl: 300
           minecraft_home: /srv/minecraft
           minecraft_version: 26.1.2
           minecraft_java_package: openjdk-25-jre-headless
           minecraft_accept_eula: true
+          minecraft_server_properties:
+            level-name: "${WORLD}"
           EOF
 
       - name: Provision droplet
@@ -147,14 +165,17 @@ jobs:
       - name: Write workflow summary
         env:
           DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          WORLD: ${{ inputs.world }}
         run: |
+          FQDN="${WORLD}.minecraft.${DNSIMPLE_DOMAIN}"
           {
             echo "## Minecraft server provisioned"
             echo
-            echo "- **FQDN:** \`minecraft-server.${DNSIMPLE_DOMAIN}\`"
+            echo "- **World:** \`${WORLD}\`"
+            echo "- **FQDN:** \`${FQDN}\`"
             echo "- **IP:** \`${{ steps.droplet.outputs.ip }}\`"
             echo "- **Region:** \`${{ inputs.region }}\`"
             echo "- **Size:** \`${{ inputs.size }}\`"
             echo "- **Auto-destroy after:** ${{ inputs.duration_hours }}h (\`${{ steps.expiry.outputs.human }}\`)"
-            echo "- **Connect:** \`minecraft-server.${DNSIMPLE_DOMAIN}:25565\`"
+            echo "- **Connect:** \`${FQDN}:25565\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Generate vars/server.yml
         env:
-          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          DNSIMPLE_DOMAIN: ${{ vars.DNSIMPLE_DOMAIN }}
           REGION: ${{ inputs.region }}
           SIZE: ${{ inputs.size }}
           DURATION_HOURS: ${{ inputs.duration_hours }}
@@ -164,7 +164,7 @@ jobs:
 
       - name: Write workflow summary
         env:
-          DNSIMPLE_DOMAIN: ${{ secrets.DNSIMPLE_DOMAIN }}
+          DNSIMPLE_DOMAIN: ${{ vars.DNSIMPLE_DOMAIN }}
           WORLD: ${{ inputs.world }}
         run: |
           FQDN="${WORLD}.minecraft.${DNSIMPLE_DOMAIN}"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Three workflows under `.github/workflows/` let anyone with repo write access spi
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `provision.yml` | Manual (`workflow_dispatch`) | Create droplet, attach `minecraft-data` volume, install server. Inputs: region, size, `duration_hours` (used for auto-destroy). |
+| `provision.yml` | Manual (`workflow_dispatch`) | Create droplet, attach `minecraft-data` volume, install server. Inputs: region, size, `duration_hours` (used for auto-destroy), `world` (lowercase letters / digits / hyphens — drives both the DNS hostname `<world>.minecraft.<domain>` and Minecraft's `level-name`, so each world keeps its own subdirectory on the persistent volume). |
 | `destroy.yml` | Manual (`workflow_dispatch`) | Stop service, unmount volume, destroy droplet, remove DNS record. |
 | `auto-destroy.yml` | Cron (`*/15 * * * *`) | Inspect live droplet's `expires-<unix>` tag and run the destroy flow once the TTL has passed. |
 

--- a/README.md
+++ b/README.md
@@ -140,14 +140,21 @@ All three share concurrency group `minecraft-server` so they cannot race each ot
 | `DO_API_KEY` | DigitalOcean API token (same scopes as for local `make provision`). |
 | `DNSIMPLE_ACCOUNT_EMAIL` | DNSimple account email. |
 | `DNSIMPLE_ACCOUNT_API_TOKEN` | DNSimple API token. |
-| `DNSIMPLE_DOMAIN` | Apex domain that will host the `minecraft.<domain>` A record. |
 | `ANSIBLE_SSH_PRIVATE_KEY` | Persistent SSH private key the workflows use to manage the droplet. Generate once with `ssh-keygen -t ed25519 -N '' -f keys/ansible -C minecraft-ci` locally and copy the file contents into the secret. |
 | `ANSIBLE_SSH_PUBLIC_KEY` | Matching public key. |
+
+### Required repository variables
+
+Variables (Settings → Secrets and variables → Actions → **Variables tab**) are non-sensitive — unlike secrets, their values are not masked in workflow logs or step summaries.
+
+| Variable | Purpose |
+|----------|---------|
+| `DNSIMPLE_DOMAIN` | Apex zone that hosts the `<world>.minecraft.<domain>` A record (e.g. `the-reagans.com`). |
 
 ### One-time GitHub setup
 
 1. **Repository → Settings → Environments**: create `minecraft-server`, add yourself (and any other write-access users) under **Required reviewers**.
-2. **Repository → Settings → Secrets and variables → Actions**: add the secrets above.
+2. **Repository → Settings → Secrets and variables → Actions**: add the secrets and variables above.
 3. (Optional) Restrict `workflow_dispatch` to specific actors via branch protection / environment policies if the repo is public.
 
 ### Running


### PR DESCRIPTION
## Summary
- New \`world\` input on \`provision.yml\` (free-text, regex-validated 1-30 chars of \`[a-z0-9-]\`, default \`world\`).
- That single value drives three things:
  - DNS hostname \`<world>.minecraft.<DNSIMPLE_DOMAIN>\`
  - Minecraft \`level-name\` via the role's \`minecraft_server_properties\` lineinfile loop, so each world lives in \`/srv/minecraft/<world>/\` on the persistent volume
  - A \`world-<name>\` droplet tag so \`destroy.yml\` and \`auto-destroy.yml\` can recover the hostname without an explicit input
- Destroy flows look up the droplet first, parse the \`world-*\` tag, then render \`vars/server.yml\` with the matching hostname before running \`playbooks/destroy.yml\`.

Closes #21.

## Prerequisite
Delete the legacy \`minecraft.the-reagans.com\` CNAME (currently points to \`cassie.the-reagans.com\`, created 2020-03-16) in DNSimple before the first \`provision.yml\` run. DNS RFC forbids any other record at a name that has a CNAME, including subdomains, so \`<world>.minecraft.<domain>\` lookups won't resolve while the CNAME exists.

## Test plan
- [x] YAML syntax check on all three workflows
- [ ] After CNAME removed, dispatch \`provision.yml\` with \`world: world\` and confirm:
  - DNSimple A record \`world.minecraft.<domain>\` created
  - Droplet has \`world-world\` tag
  - \`/srv/minecraft/world/\` populated, \`level-name=world\` in \`server.properties\`
  - Minecraft client connects via \`world.minecraft.<domain>:25565\`
- [ ] Dispatch \`provision.yml\` again with \`world: creative\` and confirm:
  - \`creative.minecraft.<domain>\` resolves to the new droplet
  - \`/srv/minecraft/creative/\` is a fresh world dir alongside the existing \`world/\`
  - \`level-name=creative\`
- [ ] \`destroy.yml\` reads the \`world-*\` tag and removes the right A record
- [ ] \`auto-destroy.yml\` (cron) cleans up after the TTL passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)